### PR TITLE
Source file url may be undefined

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -44,12 +44,20 @@ export function parse(code: string, url?: string): ParsedTemplate {
 export function generate(parsed: ParsedTemplate, options?: CompileScopeOptions): CodeWithMap {
     try {
         const sourceMap = compileToJS(parsed.ast, options);
-        sourceMap.setSourceContent(parsed.url, parsed.code);
-        const result = sourceMap.toStringWithSourceMap({ file: parsed.url });
-        return {
-            code: result.code,
-            map: result.map.toJSON()
-        };
+
+        if (parsed.url) {
+            sourceMap.setSourceContent(parsed.url, parsed.code);
+
+            const result = sourceMap.toStringWithSourceMap({ file: parsed.url });
+
+            return {
+                code: result.code,
+                map: result.map.toJSON()
+            };
+        }
+
+        return { code: sourceMap.toString(), map: null };
+
     } catch (err) {
         if (err instanceof ENDCompileError) {
             const { loc } = err.node;

--- a/test/template-generator.ts
+++ b/test/template-generator.ts
@@ -72,4 +72,11 @@ describe('Template generator', () => {
         const fixture = read('./fixtures/svg.js');
         assert.equal(code.trim(), fixture);
     });
+
+    it('should generate code without file url', () => {
+        const { code } = compile(read('./samples/svg.html'));
+        const fixture = read('./fixtures/svg.js');
+
+        assert.equal(code.trim(), fixture);
+    });
 });


### PR DESCRIPTION
In typings url is not required parameter, but if it is `undefined` throws an error. This PR should fix case when url to original file is missing. 